### PR TITLE
Add links to DataMade jshintrc, remove empty folder

### DIFF
--- a/handy-files/.jshintrc
+++ b/handy-files/.jshintrc
@@ -1,5 +1,0 @@
-{
-  "bitwise": true,
-  "eqeqeq": true,
-  "freeze": true
-}

--- a/intro-to-javascript-testing.md
+++ b/intro-to-javascript-testing.md
@@ -45,9 +45,23 @@ Alternatively, JSHint can recursively discover all JS files in a directory and r
 my_unique_app/static/js/lib/*
 ```
 
-You can configure the rules JSHint uses to lint your code via a [`.jshintrc` file](http://jshint.com/docs/). This file contains a JSON object that activates JSHint options.
+You can configure the rules JSHint uses to lint your code via a [`.jshintrc` file](http://jshint.com/docs/). This file contains a JSON object that activates JSHint options. DataMade has [a standard `.jshintrc` template](https://github.com/datamade/node-style-guide/blob/master/.jshintrc). Use it to initiate testing with JSHint, and [customize it](http://jshint.com/docs/options/) to fit the needs of your project.
 
-DataMade has [a standard `.jshintrc` template](https://github.com/datamade/node-style-guide/blob/master/.jshintrc). Use it to initiate testing with JSHint, and [customize it](http://jshint.com/docs/options/) to fit the needs of your project.
+If you know a discrete portion of your code is not `jshint` compliant, but you want to leave your config in tact for the rest, you can tell `jshint` to ignore a line or code block using the `ignore` directive, like so:
+
+```javascript
+// Ignore a line.
+console.log('please leave me be!'); // jshint ignore:line
+
+// Ignore a code block.
+/* jshint ignore:start */
+function rulebreaker(i) {
+    alert(i);
+}
+/* jshint ignore:end */
+```
+
+Note that this maneuver should _not_ be used just to get the tests to pass, but rather when there is not a better alternative. For example, JSHint complains when you leave a `console.log` in your code, but there are legitimate use cases for logging to the console in production, as in Councilmatic, where [we log the OCD ID of the entity being viewed](https://github.com/datamade/django-councilmatic/blob/5cc8ae50e8b0cf305afae563dd8deb29731204e7/councilmatic_core/templates/councilmatic_core/person.html#L232).
 
 The JSHint CLI allows for automated testing with Travis. Include in your `.travis.yml` file instructions for installing `jshint` and directive(s) for running the linter:
 

--- a/intro-to-javascript-testing.md
+++ b/intro-to-javascript-testing.md
@@ -7,23 +7,23 @@
 
 ## The right style
 
-JavaScript, as a language itself, does not have too many opinions. Functional, reliable, error-free JS comes in a variety of colors and shapes: in fact, the number of ways to [declare a function](https://www.bryanbraun.com/2014/11/27/every-possible-way-to-define-a-javascript-function/) reaches double digits. The flexibility of JS can create headaches, inspire pure rage, and ruin an afternoon. 
+JavaScript, as a language itself, does not have too many opinions. Functional, reliable, error-free JS comes in a variety of colors and shapes: in fact, the number of ways to [declare a function](https://www.bryanbraun.com/2014/11/27/every-possible-way-to-define-a-javascript-function/) reaches double digits. The flexibility of JS can create headaches, inspire pure rage, and ruin an afternoon.
 
-Narrow your options! As you write code and tests-for-your-code, check your JS against a style guide. Consistent style makes code easier to test and debug, while also minimizing cross-browser errors – a considerable pain point in JS. 
+Narrow your options! As you write code and tests-for-your-code, check your JS against a style guide. Consistent style makes code easier to test and debug, while also minimizing cross-browser errors – a considerable pain point in JS.
 
-At DataMade, we recommend [our fork of the Node.js style guide](https://github.com/datamade/node-style-guide), a simple overview of best JS practices identified by [Felix Geisendörfer](http://felixge.de/). The [Crockford conventions](http://javascript.crockford.com/code.html) nicely complement the Node.js style guide: in it, [Douglas Crockford](https://en.wikipedia.org/wiki/Douglas_Crockford) gives a no-nonsense discussion of how to write "publication quality" JavaScript. 
+At DataMade, we recommend [our fork of the Node.js style guide](https://github.com/datamade/node-style-guide), a simple overview of best JS practices identified by [Felix Geisendörfer](http://felixge.de/). The [Crockford conventions](http://javascript.crockford.com/code.html) nicely complement the Node.js style guide: in it, [Douglas Crockford](https://en.wikipedia.org/wiki/Douglas_Crockford) gives a no-nonsense discussion of how to write "publication quality" JavaScript.
 
 ## jshint
 
-An impeccable style guide, however, does not prevent human error. Every coder has at least one horror story about an hours-long hunt for a missing semicolon that caused the (sometimes silent) crash of an entire program. 
+An impeccable style guide, however, does not prevent human error. Every coder has at least one horror story about an hours-long hunt for a missing semicolon that caused the (sometimes silent) crash of an entire program.
 
-[`jshint`](http://jshint.com/about/) can be the hero in these stories. `jshint` analyzes JavaScript line-by-line and reports typos and common bug-causing mistakes.  
+[`jshint`](http://jshint.com/about/) can be the hero in these stories. `jshint` analyzes JavaScript line-by-line and reports typos and common bug-causing mistakes.
 
 Easily integrate `jshint` into your workflow using one of three strategies:
 
-* Spotcheck code! Copy-and-paste select lines of potentially error-raising JS in the [`jshint` online console](http://jshint.com/). 
+* Spotcheck code! Copy-and-paste select lines of potentially error-raising JS in the [`jshint` online console](http://jshint.com/).
 * Enable `jshint` as a constant, nagging reminder of JS best practices: add a JSHint plugin to your preferred code editor. At DataMade, many of us start on and continue using Sublime. For those Sublime users, install [JSHint Gutter](https://github.com/victorporof/Sublime-JSHint) through the Sublime package manager, and activate it by right clicking and selecting `JSHint --> Lint Code`. The results may be enlightening, but also exhausting: fix what needs fixing, and then clear the annotations with `CMD + esc`.
-* Install the `jshint` [command line interface](http://jshint.com/docs/cli/), and integrate it with the regular running of your test suite. Run `npm install -g jshint` to install JSHint globally. Then, in terminal, tell JSHint to lint your files. 
+* Install the `jshint` [command line interface](http://jshint.com/docs/cli/) and [the standard DataMade linting rules](https://github.com/datamade/node-style-guide/blob/master/.jshintrc), and integrate it with the regular running of your test suite. Run `npm install -g jshint` to install JSHint globally. Then, in terminal, tell JSHint to lint your files.
 
 The `jshint` CLI has several options. Most simply, the `jshint` command accepts a specific file as a parameter:
 
@@ -45,17 +45,9 @@ Alternatively, JSHint can recursively discover all JS files in a directory and r
 my_unique_app/static/js/lib/*
 ```
 
-JSHint allows for finer configuration via a [`.jshintrc` file](http://jshint.com/docs/). This file contains a JSON object that activates JSHint options. For example, [bitwise](http://jshint.com/docs/options/#bitwise) raises an error if the code contains a bitwise operator, such as `|`. [eqeqeq](http://jshint.com/docs/options/#eqeqeq) raises an error if the code includes a less strict equality operator: `!=` or `==`:
+You can configure the rules JSHint uses to lint your code via a [`.jshintrc` file](http://jshint.com/docs/). This file contains a JSON object that activates JSHint options.
 
-```
-{
-  "bitwise": true,
-  "eqeqeq": true
-  ...
-}
-```
-
-DataMade has [a standard `.jshintrc` template](/handy-files/.jshintrc) - use it to initiate testing with JSHint, and customize it to fit the needs of your project. 
+DataMade has [a standard `.jshintrc` template](https://github.com/datamade/node-style-guide/blob/master/.jshintrc). Use it to initiate testing with JSHint, and [customize it](http://jshint.com/docs/options/) to fit the needs of your project.
 
 The JSHint CLI allows for automated testing with Travis. Include in your `.travis.yml` file instructions for installing `jshint` and directive(s) for running the linter:
 
@@ -69,16 +61,16 @@ install:
 
 ...
 
-script: 
+script:
 - pytest tests
 - jshint my_unique_app/static/js/custom.js
 
 ...
-``` 
+```
 
 ## jasmine
 
-The right style and perfect syntax make for clean, readable, debuggable JavaScipt. Yet, testing JS functionality requires something distinct. For this, we recommend [Jasmine](https://jasmine.github.io/2.0/introduction.html), a testing framework for behavior-driven development. 
+The right style and perfect syntax make for clean, readable, debuggable JavaScipt. Yet, testing JS functionality requires something distinct. For this, we recommend [Jasmine](https://jasmine.github.io/2.0/introduction.html), a testing framework for behavior-driven development.
 
 ### Python integration
 
@@ -140,7 +132,7 @@ describe("Test custom.js", function() {
 });
 ```
 
-Reload `http://127.0.0.1:8888`, and the browser should show the number of tests and the number of failures: "finished in 0.007s 1 spec, 0 failures". 
+Reload `http://127.0.0.1:8888`, and the browser should show the number of tests and the number of failures: "finished in 0.007s 1 spec, 0 failures".
 
 ### Resources to consider for advanced integrated testing
 
@@ -148,4 +140,4 @@ At DataMade, we are actively trying to improve our testing protocols. We hope to
 
 * [django-jasmine](https://github.com/jakeharding/django-jasmine)
 * [django.js for Jasmine views](http://djangojs.readthedocs.io/en/latest/test.html)
-  
+


### PR DESCRIPTION
I made fewer changes than this diff suggests – my code editor stripped extra whitespace! 

I figure we should only maintain one copy of the `.jshintrc`, and the JS styleguide fork seemed like a more appropriate place, so I deleted it from this repo.

And, I added links [here](https://github.com/datamade/testing-guidelines/compare/jshint?expand=1#diff-de9f69ecc2c8f672b6be9cbe7ba9e2c9R50) and [here](https://github.com/datamade/testing-guidelines/compare/jshint?expand=1#diff-de9f69ecc2c8f672b6be9cbe7ba9e2c9R26) to the remote config file.