### PR TITLE
Extend mock & Django testing patterns, improve examples, revise scope guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Practicing BDD means creating a "spec" for each feature prior to implementation.
 
 Whether or not you use tests to spec, document what you are testing in docstrings or comments, particularly where queries or clever assertions are involved.
 
-Tests should operate independently of the outside world, and of each other. Use fixtures to create reusable data, whether it’s in a database or available through the fixture itself. Ideally, all non-database fixtures should be scoped to the function level. Document where fixtures exceed this scope, and be sure your tests return those fixtures to their original state, where applicable. For instance, if your fixture refers to a database table and your test alters that table, revert your changes at the end of your test.
+Tests should operate independently of the outside world, and of each other. Use fixtures to create reusable data, whether it’s in a database or available through the fixture itself. Ideally, all fixtures should be scoped to the function level and your test environment should be automatically returned to its original state after each test. Where this is not possible, document where fixtures violate this expectation, and be sure your tests clean up after themselves. For instance, if you use a module-scoped database table fixture in a test that test alters said table, any alterations should be reverted at the end of the test.
 
 **When should I run tests?**
 
@@ -65,7 +65,16 @@ In the event that a test fails, unless the functionality of the method has mater
 
 ## Examples
 
-* [`dedupe`](https://github.com/dedupeio/dedupe) – test functionality of DataMade's fuzzy matching library
+### Django
+
 * [`django-councilmatic`](https://github.com/datamade/django-councilmatic/blob/master/councilmatic_core/tests.py) – test all endpoints in a Councilmatic instance are valid
-* [`large-lots`](https://github.com/datamade/large-lots/tree/master/lots_admin/tests) - test Django management command in Large Lots sends notifications and updates the database accordingly
+* [`la-metro-councilmatic`](https://github.com/datamade/la-metro-councilmatic/tree/master/tests) - test assorted formatting and display behaviors in a custom Councilmatic instance
+* [`large-lots`](https://github.com/datamade/large-lots/tree/master/tests) - test a variety of functionality in a Django app, from form submission and validation, to distributed review tasks, to Django management commands
+
+### Flask
+
 * [`occrp`](https://github.com/datamade/occrp-timeline-tool/tree/master/tests) – test Flask form submission and page content rendering
+
+### Python libraries
+
+* [`dedupe`](https://github.com/dedupeio/dedupe) – test functionality of DataMade's fuzzy matching library

--- a/README.md
+++ b/README.md
@@ -58,6 +58,11 @@ In the event that a test fails, unless the functionality of the method has mater
 * [`pytest` 301](/framework-specific-patterns.md)
   * Testing Flask applications
   * Testing Django applications
+    * Setup
+    * Interacting with the database
+    * Transactional context
+    * Model object fixtures
+    * Management commands
 * [Front-end testing](/intro-to-javascript-testing.md)
   * The right style
   * Test your syntax with `jshint`

--- a/framework-specific-patterns.md
+++ b/framework-specific-patterns.md
@@ -40,11 +40,11 @@ def app():
 
 Once you complete this setup, you do not need to include the `app` fixture in any other fixtures or methods; it just lives there in the ether as context.
 
-Meanwhile, `pytest-flask` also includes a built-in `client` fixture. Simply include it in tests where you’d like to GET or POST to Flask routes –
+Meanwhile, `pytest-flask` also includes a built-in `client` fixture. Simply include it in tests where you'd like to GET or POST to Flask routes –
 
 ```python
 def test_get_index(client):
-    rv = client.get(‘/’)
+    rv = client.get('/')
     assert rv.status_code == 200
 ```
 
@@ -52,21 +52,23 @@ def test_get_index(client):
 
 ```python
 def test_builds_https(client):
-    assert url_for(‘/’).startswith(‘https’)
+    assert url_for('/').startswith('https')
 ```
 
 – or complete a Flask session transaction.
 
 ```python
 def test_delete_from_session(client):
-    del session[‘foo’]
+    del session['foo']
     session.modified = True
-    assert ‘foo’ not in session
+    assert 'foo' not in session
 ```
 
 ## Django
 
-`pytest-django`, a plugin for pytest, simplifies the task of integrating pytest with Django apps.
+[`pytest-django`](https://pytest-django.readthedocs.io/en/latest/), a plugin for pytest, simplifies the task of integrating pytest with Django apps.
+
+### Setup
 
 First, install it.
 
@@ -76,19 +78,102 @@ pip install pytest-django
 
 Then, add your freshly installed version of pytest-django to `requirements.txt`.
 
-Most likely, your app has local/production, general, or custom settings. For testing, some content from these files should be included in `test_config.py` in your tests directory. Set up `test_config.py`, and tell Django where to find it:
+Most likely, your app has local/production, general, or custom settings. For testing, some content from these files should be included in `test_config.py` in your tests directory. Set up `test_config.py`:
+
+**`tests/test_config.py`** (YMMV)
+```python
+import os
+
+
+SECRET_KEY = 'some secret key'
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.messages',
+    'django.contrib.staticfiles',
+    'storages',
+    ... YOUR APPS ...
+    'debug_toolbar',
+    'django.contrib.postgres',
+]
+
+MIDDLEWARE = [
+    'django.middleware.security.SecurityMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.messages.middleware.MessageMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
+]
+
+ROOT_URLCONF = 'YOUR_PROJECT.urls'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'YOUR_DATABASE',
+        'USER': '',
+        'PASSWORD': '',
+        'HOST': 'localhost',
+        'PORT': '5432',
+    }
+}
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
+STATIC_URL = '/static/'
+
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+STATICFILES_DIRS = (
+    os.path.join(BASE_DIR, "YOUR_PROJECT", "static"),
+)
+```
+
+Then, tell Django where to find it:
 
 ```bash
 export DJANGO_SETTINGS_MODULE=tests.test_config
 ```
 
-You are ready to write a test! Create a test file (remember to use `test` as a filename prefix or suffix), and import pytest at the top:
+### Interacting with the database
+
+`pytest-django` handles the work of creating and tearing down your database, for you. (By default, it's called `test_` plus the name of the database you defined in `test_config.py`)
+
+However, `pytest-django` also treats the database as lava: Your tests will fail if they try to interact with it. This is great if you agree that the database is lava. At DataMade, we aren't so sure.
+
+To grant a test access to your database, use the `django_db` mark.
 
 ```python
 import pytest
+
+@pytest.mark.django_db
+def test_cat_detail():
+    # a test with access to the database
 ```
 
-Let’s start with basics – a simple URL test. The below outlines how to write a test for a detail view for a Cat model.
+Now you are ready to write a test!
+
+Among [other very useful fixtures](http://pytest-django.readthedocs.io/en/latest/helpers.html), `pytest-django` includes a `client` fixture providing you access to the [Django test client](https://docs.djangoproject.com/en/dev/topics/testing/tools/#the-test-client), so you can GET and POST to routes, to your heart's content. Let's use the `client` fixture to test the detail route for a `Cat` object.
 
 ```python
 import pytest
@@ -100,35 +185,69 @@ from my_app.models import Cat
 @pytest.mark.django_db
 def test_cat_detail(client):
     # Create a new cat
-    kitten = Cat.create(name=’Teresa’)
+    kitten = Cat.create(name='Teresa')
 
-    # Create and call the URL (with Django’s `reverse` function)
-    url = reverse(‘detail’, kwargs={‘pk’: kitten.id})
-
+    # Create and call the URL
+    url = reverse('detail', kwargs={'pk': kitten.id})
     response = client.get(url)
 
     # Test the success of the response code
     assert response.status_code == 200
 ```
 
+### Transactional context
+
+But wait! Doesn't creating a new `Cat` object without cleaning it up violate our standard to return test context to its original state, every time? Nope! `pytest-django` runs all database operations in a transaction, then rolls them back at the end of the test.
+
+It is important to note that there are two, distinct types of transactional context. The default **does not insert any data into the database**. Objects you create in the ORM will be accessible via the ORM, but if the code you are testing runs raw SQL against the database, your new object will not be there.
+
+If the code under test queries the database directly, you can configure Django to push new data to the database with the `transaction` argument.
+
+```python
+@pytest.mark.django_db(transaction=True)
+def test_that_pushes_data_to_the_database():
+    Cat.objects.create(name='Felix')
+
+    with connection.cursor() as cursor:
+        cursor.execute('''
+            SELECT * FROM cats WHERE name = 'Felix'
+        ''')
+```
+
+#### Special case: Fixtures
+
+If you need to push data to the database in a fixture, use the `django_db` mark as above, and include the `transactional_db` fixture in your fixture.
+
+```python
+@pytest.mark.django_db(transaction=True)
+def a_fixture(transactional_db):
+    # data is pushed to the database
+```
+
+If you're interested in the mechanics of Django's transactional test context, our very own Jean Cochrane [wrote an excellent blog post](https://jeancochrane.com/blog/django-test-transactions) that's well worth your time!
+
+### Model object fixtures
+
+This pattern is great for one test, but creating the same model instance over and over becomes wearisome, fast, especially when your models have many fields to populate. That's where fixtures come in.
+
+# TO-DO: Expound real quick on fixtures & MGMT commands.
+
+### Management commands
+
 Your Django apps may have management commands, which may aid our application in significant ways – from sending emails to importing new content into your database. Such commands require tests. The below outlines how to create a database, call a management command, and test the results.
 
 ```python
 import pytest
 import sys
-from unittest.mock import patch
 
 from django.core.management import import_data
 
 from my_app.models import Cat
 
-# give the test function access to the test database, by marking it as such
-
 @pytest.mark.django_db
-# pass in a fixture that creates a database
-def test_command(django_db_setup):
-    with patch.object(Command, ‘import_data’) as mock_import:
-        call_command(‘import_data’, stdout=sys.stdout)
+def test_command(mocker):
+    with mocker.patch.object(Command, 'import_data') as mock_import:
+        call_command('import_data', stdout=sys.stdout)
 
     # `import_data` adds cats to the database – check that those cats exist.
     kittens = Cats.objects.all()

--- a/intermediate-python-testing.md
+++ b/intermediate-python-testing.md
@@ -154,7 +154,11 @@ If two or more fixtures that make up your cumulative fixtures are parameterized,
 
 ## Database fixtures
 
-Many of our web applications include databases. When they do, it’s important to test your SQL or ORM queries to ensure you’re accessing – or updating – the information you expect. To do that, we need to define a database fixture.
+Many of our web applications include databases. When they do, it’s important to test your SQL or ORM queries to ensure you’re accessing – or updating – the information you expect.
+
+**If you are writing a Django app,** you get much of the following for free. Head over to [`pytest 301`](/framework-specific-patterns.md) to learn more. If you're new to `pytest`, [don't miss the introduction to fixture scope](#scope-or-how-to-avoid-confusing-dependencies-between-your-tests) below.
+
+**For roll-your-own database testing (i.e., you're using Flask),** we need to define database fixtures manually.
 
 First, define a test database connection string in `test_config.py`.
 
@@ -166,9 +170,6 @@ DB_OPTS = {
     password=’’,
     port=5432,
 }
-
-DB_FMT = 'postgresql+dedupe://{username}:{password}@{host}:{port}/{database}'
-DB_CONN = DB_FMT.format(**DB_OPTS)
 ```
 
 `pytest_postgresql` is a `pytest` extension that provides convenience methods for creating and dropping your test database.
@@ -187,18 +188,17 @@ Then, import the convenience methods, `init_postgresql_database` and `drop_postg
 
 ```python
 from pytest_postgresql.factories import init_postgresql_database, drop_postgresql_database
-from .test_config import DB_OPTS, DB_CONN
+from .test_config import DB_OPTS
 
 @pytest.fixture(scope='session')
 def database(request):
-    pg_host = DB_OPTS.get("host")
-    pg_port = DB_OPTS.get("port")
-    pg_user = DB_OPTS.get("username")
+    pg_host = DB_OPTS["host"]
+    pg_port = DB_OPTS["port"]
+    pg_user = DB_OPTS["username"]
     pg_db = DB_OPTS["database"]
+
     init_postgresql_database(pg_user, pg_host, pg_port, pg_db)
 ```
-
-DataMaders: If you need to add extensions to your test database, see [the `database` fixture in `dedupe-service`](https://github.com/datamade/dedupe-service/blob/master/tests/conftest.py).
 
 ### Scope, or How to avoid confusing dependencies between your tests
 
@@ -208,11 +208,15 @@ Notice the scope keyword argument in the `fixture` decorator above. Scope determ
 * `module` – Fixture is run once per test module
 * `function` – Fixture is run every time a test includes it
 
-**Fixtures are function-scoped by default.** You should use this default unless you have a compelling reason. For example, it would be silly to re-create a database for every test. It is appropriate to use the `session` scope for fixtures that establish context that you aren’t going to change over the course of your testing, such as creating a database, initializing an application, or inserting immutable dummy data.
+#### Fixtures are function-scoped by default.
 
-**Be cautious!** Changes made to broadly scoped fixtures persist for all other tests in that session or module. This can lead to confusing circumstances where you are unsure whether your test is failing or the fixture context you expect was changed by a previous test.
+You should use this default unless you have a compelling reason. For example, it would be silly to re-create a database for every test. It is appropriate to use the `session` scope for fixtures that establish context that you aren’t going to change over the course of your testing, such as creating a database, initializing an application, or inserting _immutable_ dummy data.
 
-To diagnose these unintended dependencies, run your tests in a random order with [`pytest-randomly`](https://pypi.python.org/pypi/pytest-randomly). Simply:
+#### Be cautious!
+
+Changes made to broadly scoped fixtures persist for all other tests in that session or module. This can lead to confusing circumstances where you are unsure whether your test is failing or the fixture context you expect was changed by a previous test.
+
+To diagnose these unintended dependencies, you can run your tests in a random order with [`pytest-randomly`](https://pypi.python.org/pypi/pytest-randomly). Simply:
 
 ```bash
 pip install pytest-randomly
@@ -235,6 +239,8 @@ Using --randomly-seed=1510172112
 pytest --randomly-seed=1510172112
 ```
 
+#### Finalizers
+
 If you define a fixture that creates a table or inserts data that you intend to alter in your test, **use the `function` scope** and write a finalizer.
 
 A finalizer is a method, defined within a fixture and decorated with `@request.addfinalizer`, that is run when that fixture falls out of scope. In effect, finalizers should undo your fixture. If you insert data, remove the data; if you create a table, delete the table; and so on. Let's add a finalizer to our `database` fixture.
@@ -255,14 +261,103 @@ def database(request):
 
 If a more broadly scoped fixture is unavoidable, **clean up any changes** made to the fixture context at the end of every test that uses it.
 
-Even better, reconsider whether tests need alter the database at all. If you are testing a method that accepts the result of a query, do you need to create a table, populate it with dummy data, and query it just so you can run the test? Probably not! Read on for an introduction to testing with `mock`.
+Even better, reconsider whether tests need alter the database at all. If you are testing a method that accepts the result of a query, do you need to create a table, populate it with dummy data, and query it just so you can run the test? Probably not! Insert the query result into a fixture, and use the fixture to run your method directly.
+
+Working with more than one layer of state-dependent function calls? There's probably a way around it! Read on for an introduction to testing with `mock`.
 
 ## mock
 
-If a test must retrieve data from an API endpoint before processing that data, it is not a modular test. `mock` is a `unittest` submodule that allows you to remove external dependencies from your test suite by creating mocked versions of the methods or objects that rely on them.
-
-When a method or object is mocked, it is replaced by `Mock` object. This object records whether and how the patched method or object is called rather than executing the underlying code. To return to our example, you can mock your data retrieval method and test that it is called with the arguments you expect without ever touching the API.
-
-For more on `mock`, see [the quickstart](https://docs.python.org/3/library/unittest.mock.html#quick-guide) in the docs and [this excellent tutorial](https://www.toptal.com/python/an-introduction-to-mocking-in-python).
+`mock` is a `unittest` submodule that allows you to remove external dependencies from your test suite by coercing the methods that rely on them to return state _you_ control.
 
 At DataMade, we like [`pytest-mock`](https://github.com/pytest-dev/pytest-mock/), a `pytest` extension that exposes the `mock` API to your tests with the `mocker` fixture.
+
+Let's say you have a method that calls a method that queries your database and returns a result, then performs some operation on the returned result.
+
+**`foo.py`**
+```python
+def get_result():
+    # query the database and return result
+
+def do_a_thing():
+    results = get_result()
+
+    for result in results:
+        # do a thing
+```
+
+With `mock`, you can tell `get_result` to return a pre-determined list of things, instead of querying a database as written. This allows you to bypass the getting of the result (e.g., you don't need to create a database with a table to query) so you can focus on testing whether your operation does what you expect.
+
+**`test_foo.py`**
+```python
+def test_do_a_thing(mocker):
+    mocker.patch('foo.get_result', return_value=[1, 2, 3])
+
+    do_a_thing()
+
+    # does things on [1, 2, 3]
+
+    # test things were done as expected
+```
+
+If that's not tantalizing enough, you can also use `mock` to raise exceptions to test error handling, or simply turn off state-altering parts of your code that aren't relevant to the test at hand. Finally, `mock` keeps track of whether and how mocked methods are called, so you can test how your code is used (called _n_ times, or with this or that argument), without necessarily having to run it.
+
+For more on how to use `mock`, see [the quickstart](https://docs.python.org/3/library/unittest.mock.html#quick-guide) in the `mock` documention, as well as [this excellent tutorial](https://www.toptal.com/python/an-introduction-to-mocking-in-python). Meanwhile, here are a few of our own hard-won lessons from early `mock` use.
+
+#### Mock methods where they're used, not defined.
+
+Returning to our example, let's say our code were instead organized like so:
+
+**`utils.py`**
+```python
+def get_result():
+    # query the database and return result
+```
+
+**`tasks.py`**
+```python
+from utils import get_result
+
+def do_a_thing():
+    results = get_result()
+
+    for result in results:
+        # do a thing
+```
+
+If we want to mock `get_result` in a test, we must patch it in the `tasks` module, where it's used, not where it's defined:
+
+**`test_tasks.py`**
+```python
+def test_do_a_thing(mocker):
+    mocker.patch('tasks.get_result', return_value=[1, 2, 3])
+
+    do_a_thing()
+
+    # does things on [1, 2, 3]
+
+    # test things were done as expected
+```
+
+#### Mocking classes is unconventional, but not impossible.
+
+Per [the `mock` documentation](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.patch):
+
+> Patching a class replaces the class with a MagicMock instance. If the class is instantiated in the code under test then it will be the return_value of the mock that will be used.
+
+This means you first need to create a `MagicMock` instance "spec'ed" to the class you are mocking, with any methods you need to override (i.e., to return a value or raise an Exception), overridden.
+
+```python
+mocked_class = MagicMock(spec=CLASS_YOU_ARE_MOCKING)
+
+mocked_class.this_method.side_effect = AttributeError
+mocked_class.that_method.return_value = 'nyan nyan nyan'
+```
+
+<sup><strong>Note:</strong> Spec'ing means your mock object shares attributes and methods with your class. If you try to access an attribute or call a method incorrectly, i.e., without positional arguments, on a spec'ed mock object, it will raise an exception. This is in contrast to an unspec'ed mock object, which will let  you access any attribute or call any function you want without complaint. Spec'ing ensures your tests align with the API in your code base and stay in line as it changes (because your mock objects will break if they fall out of date).</sup>
+
+Then, you need to patch the class you'd like to mock, and set its `return_value` to the `MagicMock` we just made.
+
+```python
+mock_handle = mock.patch('path.to.CLASS_YOU_ARE_MOCKING')
+mock_handle.return_value = mocked_class
+```

--- a/intermediate-python-testing.md
+++ b/intermediate-python-testing.md
@@ -208,13 +208,9 @@ Notice the scope keyword argument in the `fixture` decorator above. Scope determ
 * `module` – Fixture is run once per test module
 * `function` – Fixture is run every time a test includes it
 
-#### Fixtures are function-scoped by default.
+Fixtures are function-scoped by default. You should use this default unless you have a compelling reason. For example, it would be silly to re-create a database for every test. It is appropriate to use the `session` scope for fixtures that establish context that you aren’t going to change over the course of your testing, such as creating a database, initializing an application, or inserting _immutable_ dummy data.
 
-You should use this default unless you have a compelling reason. For example, it would be silly to re-create a database for every test. It is appropriate to use the `session` scope for fixtures that establish context that you aren’t going to change over the course of your testing, such as creating a database, initializing an application, or inserting _immutable_ dummy data.
-
-#### Be cautious!
-
-Changes made to broadly scoped fixtures persist for all other tests in that session or module. This can lead to confusing circumstances where you are unsure whether your test is failing or the fixture context you expect was changed by a previous test.
+**Be cautious!** Changes made to broadly scoped fixtures persist for all other tests in that session or module. This can lead to confusing circumstances where you are unsure whether your test is failing or the fixture context you expect was changed by a previous test.
 
 To diagnose these unintended dependencies, you can run your tests in a random order with [`pytest-randomly`](https://pypi.python.org/pypi/pytest-randomly). Simply:
 
@@ -353,7 +349,7 @@ mocked_class.this_method.side_effect = AttributeError
 mocked_class.that_method.return_value = 'nyan nyan nyan'
 ```
 
-<sup><strong>Note:</strong> Spec'ing means your mock object shares attributes and methods with your class. If you try to access an attribute or call a method incorrectly, i.e., without positional arguments, on a spec'ed mock object, it will raise an exception. This is in contrast to an unspec'ed mock object, which will let  you access any attribute or call any function you want without complaint. Spec'ing ensures your tests align with the API in your code base and stay in line as it changes (because your mock objects will break if they fall out of date).</sup>
+<sup>**Note:** Spec'ing means your mock object shares attributes and methods with your class. If you try to access an attribute or call a method incorrectly, i.e., without positional arguments, on a spec'ed mock object, it will raise an exception. This is in contrast to an unspec'ed mock object, which will let  you access any attribute or call any function you want without complaint. Spec'ing ensures your tests align with the API in your code base and stay in line as it changes (because your mock objects will break if they fall out of date).</sup>
 
 Then, you need to patch the class you'd like to mock, and set its `return_value` to the `MagicMock` we just made.
 

--- a/intro-to-python-testing.md
+++ b/intro-to-python-testing.md
@@ -20,6 +20,10 @@ Create a tests directory at root of your main directory:
 
 Within the tests directory, add the following files:
 
+* **`__init__.py`**
+
+  An empty init file to transform your tests directory into a tests module, so imports (i.e., `import from .test_config`) work correctly.
+
 * **`test_config.py`**
 
   A configuration file that contains essential environment variables, i.e., INSTALLED_APPS, DATABASES, etc. (Careful! Do not put any secret data in here.)
@@ -50,7 +54,7 @@ Many DataMade projects use flake8 to enforce consistent and standard style patte
 
 Place a `setup.cfg` file in the root of your main directory. At the top, add a section for pytest: this tells your application to assign testing options (as they would appear in `pytest-ini`, i.e., the initialization file for `pytest`).
 
-Then, add parameters for testing setup. The below example, take from [Dedupe service](https://github.com/datamade/dedupe-service/blob/master/setup.cfg), includes precise options for flake8 + pytest integration. 
+Then, add parameters for testing setup. The below example, take from [Dedupe service](https://github.com/datamade/dedupe-service/blob/master/setup.cfg), includes precise options for flake8 + pytest integration.
 
 ```cfg
 [tool:pytest]
@@ -94,7 +98,7 @@ Executing the `pytest` framework is easy. It takes one command. Go to the root o
 pytest
 ```
 
-Pytest discovers all test modules, executes them, and prints the results to terminal. 
+Pytest discovers all test modules, executes them, and prints the results to terminal.
 
 You can hone in on particular tests, too. As suggested above, you should have a `tests` directory with individual files (i.e., test modules) or app-specific repositories. Indicate the particular module or repo, and pytest will only execute those tests:
 


### PR DESCRIPTION
- [x] `mock`
- [x] Scope
- [x] Django

Closes #8, closes #9, closes #13, closes #14